### PR TITLE
ci: add Renovate job to run every 6 hours

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -1,14 +1,12 @@
 {
   "version": "0.2",
   "language": "en",
-  "words": [
-    "Hapag",
-    "Repology"
-  ],
+  "words": ["Hapag", "Repology"],
   "ignoreWords": [
     "CODEOWNERS",
     "datasource",
     "Dockerfiles",
+    "renovatebot",
     "shuf",
     "tflint"
   ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,1 @@
+# do not use this file to configure Dependabot as we use Renovate to update the dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,1 +1,0 @@
-# do not use this file to configure Dependabot as we use Renovate to update the dependencies

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,18 @@
+name: Renovate
+on:
+  #  schedule:
+  # The "*" (#42, asterisk) character has special semantics in YAML, so this
+  # string has to be quoted.
+  #    - cron: '0/15 * * * *'
+  pull_request:
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v34.82.0
+        with:
+          configurationFile: default.js
+          token: ${{ secrets.LINT_PR_GH_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.82.0
         with:
-          configurationFile: default.js
+          configurationFile: default.json
           token: ${{ secrets.LINT_PR_GH_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,10 +1,10 @@
+---
 name: Renovate
+
 on:
-  #  schedule:
-  # The "*" (#42, asterisk) character has special semantics in YAML, so this
-  # string has to be quoted.
-  #    - cron: '0/15 * * * *'
-  pull_request:
+  schedule:
+    - cron: "37 0/6 * * *"
+
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -15,6 +15,7 @@ jobs:
         uses: renovatebot/github-action@v34.82.0
         with:
           configurationFile: default.json
-          token: ${{ secrets.LINT_PR_GH_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           RENOVATE_DRY_RUN: "full"
+          GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,7 @@
 ---
 name: Renovate
 
+# yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: "37 0/6 * * *"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           configurationFile: default.json
           token: ${{ secrets.LINT_PR_GH_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: "full"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.82.0
         with:
           configurationFile: default.json
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          RENOVATE_DRY_RUN: "full"
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Renovate-Global-Configuration
 
-Global Renovate Configuration for Hapag-Lloyd repositories.
+This repository contains the global configuration settings useful for all Hapag-Lloyd repositories. Renovate is
+scheduled to run every 6 hours on all repositories we have.
+
+## Usage
+
+Make sure to include the default configuration in your `renovate.json` file.
+
+```json
+{
+  "extends": ["github>Hapag-Lloyd/Renovate-Global-Configuration"]
+}
+```
 
 ## Default Configuration
 


### PR DESCRIPTION
# Description

This PR adds a workflow which runs Renovate on all Hapag-Lloyd repositories every 6 hours. The following secrets are needed:
- RENOVATE_TOKEN: to create PRs
- RENOVATE_GITHUB_COM_TOKEN: to access release notes on github.com

# Verification

Ran the workflow on `pull_request` in dry mode.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
