### PR TITLE
feat: pin all GitHub actions to a digest

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -4,8 +4,11 @@
   "words": ["cpus", "Hapag", "Repology"],
   "ignoreWords": [
     "amannn",
+    "autodiscover",
+    "Automerge",
     "CODEOWNERS",
     "datasource",
+    "datasources",
     "Dockerfiles",
     "dorny",
     "ibiqlik",

--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "autodiscover": true,
   "autodiscoverFilter": ["/Hapag-Lloyd/*/"],
-  "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+  "extends": ["config:base", ":semanticCommitTypeAll(chore)", "helpers:pinGitHubActionDigests"],
   "includeForks": false,
   "ignorePaths": ["**/modules/**/provider.tf"],
   "labels": ["dependency"],


### PR DESCRIPTION
# Description

As tags might change and point to a different commit, this PR introduces a Renovate helper function to pin all GitHub workflows to a digest.

# Verification

Not done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
