### PR TITLE
chore: use patch versions and Docker digests

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -1,13 +1,19 @@
 {
   "version": "0.2",
   "language": "en",
-  "words": ["Hapag", "Repology"],
+  "words": ["cpus", "Hapag", "Repology"],
   "ignoreWords": [
+    "amannn",
     "CODEOWNERS",
     "datasource",
     "Dockerfiles",
+    "dorny",
+    "ibiqlik",
+    "markdownlint",
     "renovatebot",
+    "rhysd",
     "shuf",
+    "shunsuke",
     "tflint"
   ]
 }

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -82,7 +82,7 @@ jobs:
     needs: find-changes
     if: needs.find-changes.outputs.workflow == 'true'
     container:
-      image: rhysd/actionlint:1.6.22
+      image: rhysd/actionlint:1.6.22@sha256:5f957b2a08d223e48133e1a914ed046bea12e578fe2f6ae4de47fdbe691a2468
       options: --cpus 1 --user root
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,14 +9,14 @@ on:
       - edited
       - synchronize
     branches-ignore:
-      - 'release-please--branches--*'
+      - "release-please--branches--*"
 
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.LINT_PR_GH_TOKEN }}
         with:

--- a/.github/workflows/welcome-message.yml
+++ b/.github/workflows/welcome-message.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v6.4.0
         with:
           # yamllint disable rule:line-length
           script: |


### PR DESCRIPTION
# Description

Make sure that all version numbers identify a patch version and that Docker images uses a digest to pin the exact version.

# Verification

Not done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
