### PR TITLE
feat: allow Renovate to update versions in `tflint.hcl` and `terraform.yml`

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,10 +31,14 @@
     {
       "fileMatch": [
         "(^|/|\\.)Dockerfile$",
-        "(^|/)Dockerfile[^/]*$"
+        "(^|/)Dockerfile[^/]*$",
+        "(^|/)terraform\\.yml$",
+        "(^|/)tflint\\.hcl$"
       ],
       "matchStrings": [
-        "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=\"(?<currentValue>.*)\"\\s*"
+        "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=\"(?<currentValue>.*)\"\\s*",
+        "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.+_version=\"(?<currentValue>.*)\"\\s*",
+        "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*version = \"(?<currentValue>.*)\"\\s*"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
# Description

Allows Renovate to update versions in the `terraform.yml` and `tflint.hcl`. In both files we use the `regexManager`.

# Verification

Not done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
