### PR TITLE
chore: use the full blown Renovate image

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,8 +3,7 @@ name: Renovate
 
 # yamllint disable-line rule:truthy
 on:
-  schedule:
-    - cron: "37 0/6 * * *"
+  pull_request:
 
 jobs:
   renovate:
@@ -18,5 +17,7 @@ jobs:
         with:
           configurationFile: default.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+          use_slim: false
         env:
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}
+          LOG_LEVEL: debug

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           configurationFile: default.json
           token: ${{ secrets.RENOVATE_TOKEN }}
-          use_slim: false
         env:
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}
           LOG_LEVEL: debug
+          useSlim: false

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           configurationFile: default.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+          useSlim: false
         env:
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}
           LOG_LEVEL: debug
-          useSlim: false

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,4 +22,3 @@ jobs:
           useSlim: false
         env:
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}
-          LOG_LEVEL: debug


### PR DESCRIPTION
# Description

Instead of using the slim image, this PR activates the full blown image with all managers, .... to have them available if needed.

# Verification

Check Renovate job in this feature branch to use the full image.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
