### PR TITLE
feat: enable Renovate dependency dashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "autodiscover": true,
   "autodiscoverFilter": ["/Hapag-Lloyd/*/"],
-  "extends": ["config:base", ":semanticCommitTypeAll(chore)", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:base", ":semanticCommitTypeAll(chore)", "helpers:pinGitHubActionDigests", ":dependencyDashboard"],
   "includeForks": false,
   "ignorePaths": ["**/modules/**/provider.tf"],
   "labels": ["dependency"],


### PR DESCRIPTION
# Description

Enables the Renovate dependency dashboard. This creates an issue showing the Renovate details per repository.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
