### PR TITLE
fix: use dedicated prefixes for dependency updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "autodiscover": true,
   "autodiscoverFilter": ["/Hapag-Lloyd/*/"],
-  "extends": ["config:base", ":semanticCommitTypeAll(chore)", "helpers:pinGitHubActionDigests", ":dependencyDashboard"],
+  "extends": ["config:base", ":semanticCommits", "helpers:pinGitHubActionDigests", ":dependencyDashboard"],
   "includeForks": false,
   "ignorePaths": ["**/modules/**/provider.tf"],
   "labels": ["dependency"],


### PR DESCRIPTION
# Description

Use `ci`, `fix` and `chore` for dependency updates, depending on the dependency type to be updated. `fix` is used for dependencies used in the production code. They have to be delivered to the end users as soon as possible.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
