### PR TITLE
fix: use Renovate as git author

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
   "autodiscover": true,
   "autodiscoverFilter": ["/Hapag-Lloyd/*/"],
   "extends": ["config:base", ":semanticCommits", "helpers:pinGitHubActionDigests", ":dependencyDashboard"],
+  "gitAuthor": "Renovate <info@hlag.com>",
   "includeForks": false,
   "ignorePaths": ["**/modules/**/provider.tf"],
   "labels": ["dependency"],


### PR DESCRIPTION
# Description

Commits should clearly show that they were made by Renovate. This PR sets the `gitAuthor` in the configuration file to `Renovate <info@hlag.com>`.

# Verification

None

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
