### PR TITLE
fix: use `GITHUB_TOKEN` for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,6 +7,7 @@ on:
     - cron: "37 0/6 * * *"
 
 permissions:
+  contents: write
   pull-requests: write
   
 jobs:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "37 0/6 * * *"
 
+permissions:
+  pull-requests: write
+  
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -19,6 +22,6 @@ jobs:
         uses: renovatebot/github-action@763e632d06fb55a58680de8a975a78217332d7ac # v34.132.1
         with:
           configurationFile: default.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}


### PR DESCRIPTION
# Description

Do not use a PAT but the `GITHUB_TOKEN`. This way Renovate appears as bot (and not as a normal user).

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
