### PR TITLE
revert: use `GITHUB_TOKEN` for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,10 +6,6 @@ on:
   schedule:
     - cron: "37 0/6 * * *"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -23,6 +19,6 @@ jobs:
         uses: renovatebot/github-action@763e632d06fb55a58680de8a975a78217332d7ac # v34.132.1
         with:
           configurationFile: default.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}


### PR DESCRIPTION
# Description

Renovate needs a PAT, so revert the PR using `GITHUB_TOKEN`.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
