### PR TITLE
feat: use `ci`/`test` scope for dependency updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -40,7 +40,6 @@
       "description": "Group all github-actions packages together as actions use the same digest."
     },
     {
-      "matchDatasources": ["maven"],
       "matchDepTypes": ["test"],
       "semanticCommitType": "test",
       "description": "Use the `test` prefix for Maven test dependencies."

--- a/default.json
+++ b/default.json
@@ -38,6 +38,17 @@
       "matchFileNames": [".github/workflows/*"],
       "groupName": "GitHub Actions",
       "description": "Group all github-actions packages together as actions use the same digest."
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchDepTypes": ["test"],
+      "semanticCommitType": "test",
+      "description": "Use the `test` prefix for Maven test dependencies."
+    },
+    {
+      "matchFileNames": [".github/workflows/*"],
+      "semanticCommitType": "ci",
+      "description": "Use the `ci` prefix for workflow dependencies."
     }
   ],
 


### PR DESCRIPTION
# Description

Dependency updates for workflows and test dependencies do not have to publish a new version as the changes are not end-user relevant.

This PR uses the `ci` prefix for workflow dependency updates and `test` for Maven test dependencies. Semantic release will not create a new version for those updates.

# Verification

None. Used the examples from the documentation: https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
