### PR TITLE
ci: use workflows from template repository

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,15 +7,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_linter_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_linter_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit
-
-  lint-renovate-defaults:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-
-      # a special check for the defaults
-      - uses: suzuki-shunsuke/github-action-renovate-config-validator@b54483862375f51910a60c4f498e927d4f3df466 # v1.0.1
-        with:
-          config_file_path: "default.json"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,5 +14,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_pull_request_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_pull_request_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: Create a release
+name: Release
 
 # yamllint disable-line rule:truthy
 on:
@@ -9,5 +9,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_release_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_release_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -1,5 +1,5 @@
 ---
-name: Try a release
+name: Release Test
 
 # yamllint disable-line rule:truthy
 on:
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_release_dry_run_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_release_dry_run_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/renovate_auto_approve.yml
+++ b/.github/workflows/renovate_auto_approve.yml
@@ -7,5 +7,5 @@ on: pull_request_target
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_renovate_auto_approve_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_renovate_auto_approve_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/slash_ops_command_help.yml
+++ b/.github/workflows/slash_ops_command_help.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_slash_ops_command_help_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_slash_ops_command_help_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/slash_ops_comment_dispatch.yml
+++ b/.github/workflows/slash_ops_comment_dispatch.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_slash_ops_comment_dispatch_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_slash_ops_comment_dispatch_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_spelling_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_spelling_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_stale_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_stale_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit

--- a/.github/workflows/welcome_message.yml
+++ b/.github/workflows/welcome_message.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_welcome_message_callable.yml@1ae9a1d69c582281b4312e7ca65632adb32ddee8
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_welcome_message_callable.yml@a28fa2f991164959262587011188af99a7f0cb20
     secrets: inherit


### PR DESCRIPTION
# Description

Switch to the standard workflows outlined in https://github.com/Hapag-Lloyd/Repository-Template-Simple

# Verification

Done in this feature branch.
