### PR TITLE
fix: automatically update `tflint.hcl`

### DIFF
--- a/default.json
+++ b/default.json
@@ -57,5 +57,9 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
-  ]
+  ],
+
+  "tflint-plugin": {
+    "fileMatch": ["tflint\\.hcl$"]
+  }
 }


### PR DESCRIPTION
# Description

The standard `tflint-plugin` updates `.tflint.hcl` only, but we use a different naming here (without the leading dot).

This PR adds our file pattern to Renovate to enable automatic updates on this file as well.

# Verification

None.