### PR TITLE
feat: use `ci`/`test` scope for dependency updates (#88)

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,16 @@
       "matchFileNames": [".github/workflows/*"],
       "groupName": "GitHub Actions",
       "description": "Group all github-actions packages together as actions use the same digest."
+    },
+    {
+      "matchDepTypes": ["test"],
+      "semanticCommitType": "test",
+      "description": "Use the `test` prefix for Maven test dependencies."
+    },
+    {
+      "matchFileNames": [".github/workflows/*"],
+      "semanticCommitType": "ci",
+      "description": "Use the `ci` prefix for workflow dependencies."
     }
   ],
 


### PR DESCRIPTION
# Description

Commit ef17abcbaf0ac04b8f587bd0e8acda1b66f88c5d accidentally deleted the changes in `default.json` and is reintroduced with this PR.
 
Dependency updates for workflows and test dependencies do not have to publish a new version as the changes are not end-user relevant.

This PR uses the `ci` prefix for workflow dependency updates and `test` for Maven test dependencies. Semantic release will not create a new version for those updates.

Closes #87 

# Verification

None. Used the examples from the documentation:
https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
