### PR TITLE
fix: add day of week to cron expression for github-action updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -37,7 +37,7 @@
       "matchManagers": ["github-actions"],
       "matchFileNames": [".github/workflows/*"],
       "matchRepositories": ["!Hapag-Lloyd/Renovate-Global-Configuration"],
-      "schedule": ["* * 1 * "],
+      "schedule": ["* * 1 * *"],
       "groupName": "GitHub Actions",
       "description": "Group all github-actions packages together as actions use the same digest. Updates are done on the first day of the month. Excluding this global configuration repository."
     },


### PR DESCRIPTION
# Description

Adds the day of week parameter to the cron expression. Otherwise it is invalid and not respected by Renovate. 