### PR TITLE
fix: use correct `fileMatch` to find workflow files

### DIFF
--- a/default.json
+++ b/default.json
@@ -106,7 +106,7 @@
       "customType": "regex",
       "fileMatch": ["^.github\/workflows\/.+\\.yml$"],
       "matchStrings": [
-        "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*version: \"(?<currentValue>.*)\"\\s*"
+        "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.+_version=\"(?<currentValue>.*)\"\\s*"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }

--- a/default.json
+++ b/default.json
@@ -104,7 +104,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^.github/workflows/*.yml$"],
+      "fileMatch": ["^.github\/workflows\/.+\\.yml$"],
       "matchStrings": [
         "\\s*# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*version: \"(?<currentValue>.*)\"\\s*"
       ],


### PR DESCRIPTION
There were no updates of TfLint versions in the workflow files.

- the correct escape characters were missing in the regex string.
- the regex was not matching the strings from the file as there is no `version: `